### PR TITLE
Extract more detailed information about each plugin used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -634,38 +634,39 @@ states[STATE_EVENT] = function(parser) {
             fruityWrapper(cc.pluginSettings) + " -> " + fruityWrapper(strbuf));
       }
       cc.pluginSettings = strbuf;
+      cc.plugin = {}
       var flpPluginOffset  = 0;
-      var flpPluginVersion = cc.pluginSettings.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
+      var flpPluginVersion = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
       // TODO support old <= 4 version too
       if (flpPluginVersion >= 5 && flpPluginVersion <= 16) {
-        while (flpPluginOffset < cc.pluginSettings.length) {
-          var flpPluginChunkId     = cc.pluginSettings.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
-          var flpPluginChunkSizeLo = cc.pluginSettings.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
-          var flpPluginChunkSizeHi = cc.pluginSettings.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
+        while (flpPluginOffset < strbuf.length) {
+          var flpPluginChunkId     = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
+          var flpPluginChunkSizeLo = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
+          var flpPluginChunkSizeHi = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
           var flpPluginChunkSize   = flpPluginChunkSizeLo + flpPluginChunkSizeHi * Math.pow(2,32);
           var flpPluginChunkOffset = flpPluginOffset;
           var flpPluginChunkEnd    = flpPluginOffset + flpPluginChunkSize;
           switch (flpPluginChunkId) {
             case PluginChunkIds.MIDI:
-              cc.pluginMidiInPort     = cc.pluginSettings.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
-              cc.pluginMidiOutPort    = cc.pluginSettings.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
-              cc.pluginPitchBendRange = cc.pluginSettings.readUInt8(flpPluginChunkOffset);    flpPluginChunkOffset += 1;
-              flpPluginChunkOffset   += 11; // Ignore reserved bytes.
+              cc.plugin.midiInPort     = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              cc.plugin.midiOutPort    = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              cc.plugin.pitchBendRange = strbuf.readUInt8(flpPluginChunkOffset);    flpPluginChunkOffset += 1;
+              flpPluginChunkOffset    += 11; // Ignore reserved bytes.
               break;
             case PluginChunkIds.Flags:
-              cc.pluginFlags = cc.pluginSettings.readUInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              cc.plugin.flags = strbuf.readUInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
               break;
             case PluginChunkIds.IO:
-              cc.pluginNumInputs   = cc.pluginSettings.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
-              cc.pluginNumOutputs  = cc.pluginSettings.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              cc.plugin.numInputs  = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              cc.plugin.numOutputs = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
               flpPluginChunkOffset += 8; // Ignore reserved bytes.
               break;
             case PluginChunkIds.InputInfo:
             case PluginChunkIds.OutputInfo:
               var pluginIOInfo = [];
               while (flpPluginChunkOffset < flpPluginChunkEnd) {
-                var pluginIOMixerOffset       = cc.pluginSettings.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
-                var pluginIOFlags             = cc.pluginSettings.readUInt8(flpPluginChunkOffset);    flpPluginChunkOffset += 1;
+                var pluginIOMixerOffset       = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+                var pluginIOFlags             = strbuf.readUInt8(flpPluginChunkOffset);    flpPluginChunkOffset += 1;
                 flpPluginChunkOffset         += 7; // Ignore reserved bytes.
                 pluginIOInfo.push({
                   MixerOffset : pluginIOMixerOffset,
@@ -673,41 +674,40 @@ states[STATE_EVENT] = function(parser) {
                 });
               }
               if (flpPluginChunkId === PluginChunkIds.InputInfo) {
-                cc.pluginInputInfo  = pluginIOInfo;
+                cc.plugin.inputInfo  = pluginIOInfo;
               }
               else {
-                cc.pluginOutputInfo = pluginIOInfo;
+                cc.plugin.outputInfo = pluginIOInfo;
               }
               break;
             case PluginChunkIds.PluginInfo:
-              cc.pluginInfoKind = cc.pluginSettings.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              cc.plugin.infoKind = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
               flpPluginChunkOffset += 12; // Ignore reserved bytes.
               break;
             case PluginChunkIds.VSTPlugin:
-              var vstPluginNumber = cc.pluginSettings.readUInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+              var vstPluginNumber = strbuf.readUInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
               var vstPluginId = vstPluginNumber
                 .toString(16)
                 .match(/.{1,2}/g)
                 .map(function(hex) { return String.fromCharCode(parseInt(hex,16)) })
                 .join('');
-              cc.vstPluginNumber = vstPluginNumber;
-              cc.vstPluginId = vstPluginId;
+              cc.plugin.vstNumber = vstPluginNumber;
+              cc.plugin.vstId = vstPluginId;
               break;
             case PluginChunkIds.GUID:
-              cc.pluginGUID = cc.pluginSettings.slice(flpPluginChunkOffset, flpPluginChunkEnd);
+              cc.plugin.GUID = strbuf.slice(flpPluginChunkOffset, flpPluginChunkEnd);
               break;
             case PluginChunkIds.State:
-              cc.pluginState = cc.pluginSettings.slice(flpPluginChunkOffset, flpPluginChunkEnd);
+              cc.plugin.state = strbuf.slice(flpPluginChunkOffset, flpPluginChunkEnd);
               break;
             case PluginChunkIds.Name:
-              cc.pluginName = cc.pluginSettings.toString('utf8', flpPluginChunkOffset, flpPluginChunkEnd);
-              console.warn('plugin chunk',cc.pluginName);
+              cc.plugin.name = strbuf.toString('utf8', flpPluginChunkOffset, flpPluginChunkEnd);
               break;
             case PluginChunkIds.Filename:
-              cc.pluginFilename = cc.pluginSettings.toString('utf8', flpPluginChunkOffset, flpPluginChunkEnd);
+              cc.plugin.filename = strbuf.toString('utf8', flpPluginChunkOffset, flpPluginChunkEnd);
               break;
             case PluginChunkIds.VendorName:
-              cc.pluginVendorName = cc.pluginSettings.toString('utf8', flpPluginChunkOffset, flpPluginChunkEnd);
+              cc.plugin.vendorName = strbuf.toString('utf8', flpPluginChunkOffset, flpPluginChunkEnd);
               break;
             default:
               break;

--- a/index.js
+++ b/index.js
@@ -638,7 +638,7 @@ states[STATE_EVENT] = function(parser) {
       var flpPluginOffset  = 0;
       var flpPluginVersion = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
       // NB: don't support the limited info found in flpPluginVersion <= 4.
-      if (flpPluginVersion >= 5 && flpPluginVersion <= 16) {
+      if (flpPluginVersion >= 5 && flpPluginVersion < 10) {
         while (flpPluginOffset < strbuf.length) {
           var flpPluginChunkId     = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
           var flpPluginChunkSizeLo = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;

--- a/index.js
+++ b/index.js
@@ -618,6 +618,19 @@ states[STATE_EVENT] = function(parser) {
             fruityWrapper(cc.pluginSettings) + " -> " + fruityWrapper(strbuf));
       }
       cc.pluginSettings = strbuf;
+      if (cc.pluginSettings.length >= 170) {
+        var vstPluginNumber = cc.pluginSettings.readUInt32LE(165);
+        var vstPluginId = vstPluginNumber
+          .toString(16)
+          .match(/.{1,2}/g)
+          .map(function(hex) { return String.fromCharCode(parseInt(hex,16)) })
+          .filter(function(c) { return c >= ' ' && c <= '}' })
+          .join('');
+        if (vstPluginId.length === 4) {
+          cc.vstPluginNumber = vstPluginNumber;
+          cc.vstPluginId = vstPluginId;
+        }
+      }
     }
     break;
   case FLP_Text_ChanParams:

--- a/index.js
+++ b/index.js
@@ -664,10 +664,10 @@ states[STATE_EVENT] = function(parser) {
             case PluginChunkIds.InputInfo:
             case PluginChunkIds.OutputInfo:
               var pluginIOInfo = [];
-              while (flpPluginChunkOffset < flpPluginChunkEnd) {
-                var pluginIOMixerOffset       = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
-                var pluginIOFlags             = strbuf.readUInt8(flpPluginChunkOffset);    flpPluginChunkOffset += 1;
-                flpPluginChunkOffset         += 7; // Ignore reserved bytes.
+              while (flpPluginChunkOffset + 12 <= flpPluginChunkEnd) {
+                var pluginIOMixerOffset = strbuf.readInt32LE(flpPluginChunkOffset);  flpPluginChunkOffset += 4;
+                var pluginIOFlags       = strbuf.readUInt8(flpPluginChunkOffset);    flpPluginChunkOffset += 1;
+                flpPluginChunkOffset   += 7; // Ignore reserved bytes.
                 pluginIOInfo.push({
                   MixerOffset : pluginIOMixerOffset,
                   Flags       : pluginIOFlags,

--- a/index.js
+++ b/index.js
@@ -637,7 +637,7 @@ states[STATE_EVENT] = function(parser) {
       cc.plugin = {}
       var flpPluginOffset  = 0;
       var flpPluginVersion = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;
-      // TODO support old <= 4 version too
+      // NB: don't support the limited info found in flpPluginVersion <= 4.
       if (flpPluginVersion >= 5 && flpPluginVersion <= 16) {
         while (flpPluginOffset < strbuf.length) {
           var flpPluginChunkId     = strbuf.readUInt32LE(flpPluginOffset);  flpPluginOffset += 4;


### PR DESCRIPTION
Prior to this change, the `FLP_Text_PluginParams` field was returned as an opaque binary blob. This PR digs into those blobs and extracts information about each plugin, including:
- The plugin's VST id.
- The name of the plugin vendor.
- The filename of the plugin.
- MIDI info about the plugin.
- Input and output info about the plugin.
- Various plugin flags.

Older versions of the `.flp` format lacked rich plugin information. We don't parse plugin information for these older versions -- we just return the opaque blob.
